### PR TITLE
Fix update endpoints to apply path IDs

### DIFF
--- a/src/main/java/com/aitech/rbac/controller/ActionTypeController.java
+++ b/src/main/java/com/aitech/rbac/controller/ActionTypeController.java
@@ -14,6 +14,10 @@ public class ActionTypeController {
     @GetMapping public List<ActionType> getAll() { return service.getAll(); }
     @GetMapping("/{id}") public ActionType getById(@PathVariable UUID id) { return service.getById(id); }
     @PostMapping public void create(@RequestBody ActionType entity) { service.create(entity); }
-    @PutMapping("/{id}") public void update(@PathVariable UUID id, @RequestBody ActionType entity) { service.update(entity); }
+    @PutMapping("/{id}")
+    public void update(@PathVariable UUID id, @RequestBody ActionType entity) {
+        entity.setActionTypeId(id);
+        service.update(entity);
+    }
     @DeleteMapping("/{id}") public void delete(@PathVariable UUID id) { service.delete(id); }
 }

--- a/src/main/java/com/aitech/rbac/controller/NamespaceController.java
+++ b/src/main/java/com/aitech/rbac/controller/NamespaceController.java
@@ -14,6 +14,10 @@ public class NamespaceController {
     @GetMapping public List<Namespace> getAll() { return service.getAll(); }
     @GetMapping("/{id}") public Namespace getById(@PathVariable UUID id) { return service.getById(id); }
     @PostMapping public void create(@RequestBody Namespace entity) { service.create(entity); }
-    @PutMapping("/{id}") public void update(@PathVariable UUID id, @RequestBody Namespace entity) { service.update(entity); }
+    @PutMapping("/{id}")
+    public void update(@PathVariable UUID id, @RequestBody Namespace entity) {
+        entity.setNamespaceId(id);
+        service.update(entity);
+    }
     @DeleteMapping("/{id}") public void delete(@PathVariable UUID id) { service.delete(id); }
 }

--- a/src/main/java/com/aitech/rbac/controller/PermissionController.java
+++ b/src/main/java/com/aitech/rbac/controller/PermissionController.java
@@ -14,6 +14,10 @@ public class PermissionController {
     @GetMapping public List<Permission> getAll() { return service.getAll(); }
     @GetMapping("/{id}") public Permission getById(@PathVariable UUID id) { return service.getById(id); }
     @PostMapping public void create(@RequestBody Permission entity) { service.create(entity); }
-    @PutMapping("/{id}") public void update(@PathVariable UUID id, @RequestBody Permission entity) { service.update(entity); }
+    @PutMapping("/{id}")
+    public void update(@PathVariable UUID id, @RequestBody Permission entity) {
+        entity.setPermissionId(id);
+        service.update(entity);
+    }
     @DeleteMapping("/{id}") public void delete(@PathVariable UUID id) { service.delete(id); }
 }

--- a/src/main/java/com/aitech/rbac/controller/RoleController.java
+++ b/src/main/java/com/aitech/rbac/controller/RoleController.java
@@ -14,6 +14,10 @@ public class RoleController {
     @GetMapping public List<Role> getAll() { return service.getAll(); }
     @GetMapping("/{id}") public Role getById(@PathVariable UUID id) { return service.getById(id); }
     @PostMapping public void create(@RequestBody Role entity) { service.create(entity); }
-    @PutMapping("/{id}") public void update(@PathVariable UUID id, @RequestBody Role entity) { service.update(entity); }
+    @PutMapping("/{id}")
+    public void update(@PathVariable UUID id, @RequestBody Role entity) {
+        entity.setRoleId(id);
+        service.update(entity);
+    }
     @DeleteMapping("/{id}") public void delete(@PathVariable UUID id) { service.delete(id); }
 }

--- a/src/main/java/com/aitech/rbac/controller/RolePermissionController.java
+++ b/src/main/java/com/aitech/rbac/controller/RolePermissionController.java
@@ -3,7 +3,6 @@ package com.aitech.rbac.controller;
 import com.aitech.rbac.model.RolePermission;
 import com.aitech.rbac.service.RolePermissionService;
 import org.springframework.web.bind.annotation.*;
-import java.util.*;
 
 @RestController
 @RequestMapping("/api/role_permissions")
@@ -11,9 +10,13 @@ public class RolePermissionController {
     private final RolePermissionService service;
     public RolePermissionController(RolePermissionService service) { this.service = service; }
 
-    @GetMapping public List<RolePermission> getAll() { return service.getAll(); }
-    @GetMapping("/{id}") public RolePermission getById(@PathVariable UUID id) { return service.getById(id); }
-    @PostMapping public void create(@RequestBody RolePermission entity) { service.create(entity); }
-    @PutMapping("/{id}") public void update(@PathVariable UUID id, @RequestBody RolePermission entity) { service.update(entity); }
-    @DeleteMapping("/{id}") public void delete(@PathVariable UUID id) { service.delete(id); }
+    @PostMapping
+    public void create(@RequestBody RolePermission entity) {
+        service.create(entity);
+    }
+
+    @DeleteMapping
+    public void delete(@RequestBody RolePermission entity) {
+        service.delete(entity);
+    }
 }

--- a/src/main/java/com/aitech/rbac/controller/UserController.java
+++ b/src/main/java/com/aitech/rbac/controller/UserController.java
@@ -14,6 +14,10 @@ public class UserController {
     @GetMapping public List<User> getAll() { return service.getAll(); }
     @GetMapping("/{id}") public User getById(@PathVariable UUID id) { return service.getById(id); }
     @PostMapping public void create(@RequestBody User entity) { service.create(entity); }
-    @PutMapping("/{id}") public void update(@PathVariable UUID id, @RequestBody User entity) { service.update(entity); }
+    @PutMapping("/{id}")
+    public void update(@PathVariable UUID id, @RequestBody User entity) {
+        entity.setUserId(id);
+        service.update(entity);
+    }
     @DeleteMapping("/{id}") public void delete(@PathVariable UUID id) { service.delete(id); }
 }

--- a/src/main/java/com/aitech/rbac/controller/UserRoleController.java
+++ b/src/main/java/com/aitech/rbac/controller/UserRoleController.java
@@ -14,6 +14,10 @@ public class UserRoleController {
     @GetMapping public List<UserRole> getAll() { return service.getAll(); }
     @GetMapping("/{id}") public UserRole getById(@PathVariable UUID id) { return service.getById(id); }
     @PostMapping public void create(@RequestBody UserRole entity) { service.create(entity); }
-    @PutMapping("/{id}") public void update(@PathVariable UUID id, @RequestBody UserRole entity) { service.update(entity); }
+    @PutMapping("/{id}")
+    public void update(@PathVariable UUID id, @RequestBody UserRole entity) {
+        entity.setUserId(id);
+        service.update(entity);
+    }
     @DeleteMapping("/{id}") public void delete(@PathVariable UUID id) { service.delete(id); }
 }


### PR DESCRIPTION
## Summary
- propagate path IDs to entities in update endpoints
- simplify RolePermissionController to only expose supported operations

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_68ac68f9ec80832c9ed922a860ac3974