### PR TITLE
Add GraphQL query to fetch user roles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,10 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-graphql</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.mybatis.spring.boot</groupId>
             <artifactId>mybatis-spring-boot-starter</artifactId>
             <version>3.0.3</version>

--- a/src/main/java/com/aitech/rbac/controller/UserGraphQLController.java
+++ b/src/main/java/com/aitech/rbac/controller/UserGraphQLController.java
@@ -1,0 +1,21 @@
+package com.aitech.rbac.controller;
+
+import com.aitech.rbac.model.Role;
+import com.aitech.rbac.service.RoleService;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.stereotype.Controller;
+
+import java.util.List;
+import java.util.UUID;
+
+@Controller
+public class UserGraphQLController {
+    private final RoleService roleService;
+    public UserGraphQLController(RoleService roleService) { this.roleService = roleService; }
+
+    @QueryMapping
+    public List<Role> userRoles(@Argument UUID userId) {
+        return roleService.getByUserId(userId);
+    }
+}

--- a/src/main/java/com/aitech/rbac/mapper/RoleMapper.java
+++ b/src/main/java/com/aitech/rbac/mapper/RoleMapper.java
@@ -14,6 +14,9 @@ public interface RoleMapper {
     @Select("SELECT * FROM roles WHERE role_id = #{id}")
     Role findById(UUID id);
 
+    @Select("SELECT r.* FROM roles r JOIN user_roles ur ON r.role_id = ur.role_id WHERE ur.user_id = #{userId}")
+    List<Role> findByUserId(UUID userId);
+
     @Insert("INSERT INTO roles(role_id, role_name, description, is_system_role) " +
             "VALUES(#{roleId}, #{roleName}, #{description}, #{isSystemRole})")
     void insert(Role role);

--- a/src/main/java/com/aitech/rbac/service/RoleService.java
+++ b/src/main/java/com/aitech/rbac/service/RoleService.java
@@ -6,6 +6,7 @@ import java.util.*;
 public interface RoleService {
     List<Role> getAll();
     Role getById(UUID id);
+    List<Role> getByUserId(UUID userId);
     void create(Role entity);
     void update(Role entity);
     void delete(UUID id);

--- a/src/main/java/com/aitech/rbac/service/impl/RoleServiceImpl.java
+++ b/src/main/java/com/aitech/rbac/service/impl/RoleServiceImpl.java
@@ -13,6 +13,7 @@ public class RoleServiceImpl implements RoleService {
 
     public List<Role> getAll() { return mapper.findAll(); }
     public Role getById(UUID id) { return mapper.findById(id); }
+    public List<Role> getByUserId(UUID userId) { return mapper.findByUserId(userId); }
     public void create(Role entity) { mapper.insert(entity); }
     public void update(Role entity) { mapper.update(entity); }
     public void delete(UUID id) { mapper.delete(id); }

--- a/src/main/resources/graphql/userRoles.graphqls
+++ b/src/main/resources/graphql/userRoles.graphqls
@@ -1,0 +1,10 @@
+type Role {
+  roleId: ID!
+  roleName: String!
+  description: String
+  systemRole: Boolean!
+}
+
+type Query {
+  userRoles(userId: ID!): [Role!]!
+}


### PR DESCRIPTION
## Summary
- add Spring GraphQL dependency
- expose `userRoles` GraphQL query returning a user's assigned roles
- support fetching roles by user ID in mapper and service layers

## Testing
- `mvn -q -Djava.net.preferIPv4Stack=true test` *(fails: Non-resolvable parent POM for com.aitech:rbac-full-backend:1.0.0)*


------
https://chatgpt.com/codex/tasks/task_e_68ac753e8ee8832c946224438d5801c6