### PR TITLE
Add JWT security dependencies and quote users table for H2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,27 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.11.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,3 +16,8 @@ spring:
 
 server:
   port: 8080
+
+security:
+  jwt:
+    secret-key: ${JWT_SECRET:change-me}
+    expiration: 3600000

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,4 +1,4 @@
-CREATE TABLE users (
+CREATE TABLE "users" (
     user_id UUID PRIMARY KEY DEFAULT RANDOM_UUID(),
     username VARCHAR(50) UNIQUE NOT NULL,
     email VARCHAR(100) UNIQUE NOT NULL,
@@ -36,7 +36,7 @@ CREATE TABLE resource_access (
     PRIMARY KEY (permission_id, namespace_id, action_type_id)
 );
 CREATE TABLE user_roles (
-    user_id UUID REFERENCES users(user_id) ON DELETE CASCADE,
+    user_id UUID REFERENCES "users"(user_id) ON DELETE CASCADE,
     role_id UUID REFERENCES roles(role_id) ON DELETE CASCADE,
     PRIMARY KEY (user_id, role_id)
 );

--- a/target/classes/application.yml
+++ b/target/classes/application.yml
@@ -12,3 +12,8 @@ spring:
 
 server:
   port: 8080
+
+security:
+  jwt:
+    secret-key: ${JWT_SECRET:change-me}
+    expiration: 3600000

--- a/target/classes/schema.sql
+++ b/target/classes/schema.sql
@@ -1,5 +1,5 @@
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
-CREATE TABLE users (
+CREATE TABLE "users" (
     user_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     username VARCHAR(50) UNIQUE NOT NULL,
     email VARCHAR(100) UNIQUE NOT NULL,
@@ -30,7 +30,7 @@ CREATE TABLE action_types (
     description TEXT
 );
 CREATE TABLE user_roles (
-    user_id UUID REFERENCES users(user_id) ON DELETE CASCADE,
+    user_id UUID REFERENCES "users"(user_id) ON DELETE CASCADE,
     role_id UUID REFERENCES roles(role_id) ON DELETE CASCADE,
     PRIMARY KEY (user_id, role_id)
 );


### PR DESCRIPTION
## Summary
- add Spring Security and JWT dependencies for token-based auth
- configure JWT secret and expiration settings
- quote users table name in schema to avoid H2 syntax error

## Testing
- `mvn -q test` *(fails: Could not resolve parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ac783ce6cc832caed921bbe57f4fd7