### PR TITLE
Add UUID type handler for MyBatis

### DIFF
--- a/src/main/java/com/aitech/rbac/typehandler/UUIDTypeHandler.java
+++ b/src/main/java/com/aitech/rbac/typehandler/UUIDTypeHandler.java
@@ -1,0 +1,49 @@
+package com.aitech.rbac.typehandler;
+
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.MappedTypes;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.UUID;
+
+@MappedTypes(UUID.class)
+public class UUIDTypeHandler extends BaseTypeHandler<UUID> {
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, UUID parameter, JdbcType jdbcType) throws SQLException {
+        ps.setObject(i, parameter, Types.OTHER);
+    }
+
+    @Override
+    public UUID getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        Object obj = rs.getObject(columnName);
+        return parse(obj);
+    }
+
+    @Override
+    public UUID getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        Object obj = rs.getObject(columnIndex);
+        return parse(obj);
+    }
+
+    @Override
+    public UUID getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        Object obj = cs.getObject(columnIndex);
+        return parse(obj);
+    }
+
+    private UUID parse(Object obj) {
+        if (obj == null) {
+            return null;
+        }
+        if (obj instanceof UUID uuid) {
+            return uuid;
+        }
+        return UUID.fromString(obj.toString());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,15 +4,15 @@ spring:
     username: sa
     password: ""
     driver-class-name: org.h2.Driver
-
   h2:
     console:
       enabled: true
 
-  mybatis:
-    type-aliases-package: com.aitech.rbac.model
-    configuration:
-      map-underscore-to-camel-case: true
+mybatis:
+  type-aliases-package: com.aitech.rbac.model
+  type-handlers-package: com.aitech.rbac.typehandler
+  configuration:
+    map-underscore-to-camel-case: true
 
 server:
   port: 8080


### PR DESCRIPTION
## Summary
- map `java.util.UUID` fields using a custom MyBatis type handler
- register the new handler in `application.yml`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact spring-boot-starter-parent:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_68ac81e11328832cb5ec05fd12df2f71